### PR TITLE
Fix #4: Add support for filing bugs outside of Firefox product.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
   },
   rules: {
     "no-console": "off",
+    "semi": ["error", "always"],
   },
 };


### PR DESCRIPTION
This modifies the button for filing a new bug to have a dropdown with a list of product/component combinations to file in:

<img width="237" alt="screen shot 2018-04-09 at 2 42 19 pm" src="https://user-images.githubusercontent.com/193106/38524667-4cc07bd4-3c04-11e8-8c79-47dff5b2827b.png">

@jryans r? I was a bit messy with repeated code for creating HTML elements, but this extension has like <20 users so I'm not terribly worried about that level of quality. Honestly the best thing would be to just check this branch out and test if the extension works with about:debugging.